### PR TITLE
Fix reference to jsonpath-rw

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@
 
 pbr<2.0,>=1.4
 Babel>=1.3
-jsonpath_rw
+jsonpath-rw


### PR DESCRIPTION
jsonpath-rw is the pypi name, jsonpath_rw is only accepted by pip
as a compatibility measure.