### PR TITLE
Added support for boolean values in filters

### DIFF
--- a/jsonpath_rw_ext/_filter.py
+++ b/jsonpath_rw_ext/_filter.py
@@ -80,6 +80,11 @@ class Expression(jsonpath_rw.JSONPath):
                     value = int(value)
                 except ValueError:
                     continue
+            elif isinstance(self.value, bool):
+                try:
+                    value = bool(value)
+                except ValueError:
+                    continue
 
             if OPERATOR_MAP[self.op](value, self.value):
                 found.append(data)

--- a/jsonpath_rw_ext/parser.py
+++ b/jsonpath_rw_ext/parser.py
@@ -32,10 +32,16 @@ from jsonpath_rw_ext import _string
 class ExtendedJsonPathLexer(lexer.JsonPathLexer):
     """Custom LALR-lexer for JsonPath"""
     literals = lexer.JsonPathLexer.literals + ['?', '@', '+', '*', '/', '-']
-    tokens = (parser.JsonPathLexer.tokens +
+    tokens = (['BOOL'] +
+              parser.JsonPathLexer.tokens +
               ['FILTER_OP', 'SORT_DIRECTION', 'FLOAT'])
 
     t_FILTER_OP = r'==?|<=|>=|!=|<|>'
+
+    def t_BOOL(self, t):
+        r'true|false'
+        t.value = True if t.value == 'true' else False
+        return t
 
     def t_SORT_DIRECTION(self, t):
         r',?\s*(/|\\)'
@@ -111,6 +117,7 @@ class ExtentedJsonPathParser(parser.JsonPathParser):
                       | jsonpath FILTER_OP ID
                       | jsonpath FILTER_OP FLOAT
                       | jsonpath FILTER_OP NUMBER
+                      | jsonpath FILTER_OP BOOL
         """
         if len(p) == 2:
             left, op, right = p[1], None, None

--- a/jsonpath_rw_ext/tests/test_jsonpath_rw_ext.py
+++ b/jsonpath_rw_ext/tests/test_jsonpath_rw_ext.py
@@ -302,25 +302,30 @@ class TestJsonpath_rw_ext(testscenarios.WithScenarios,
 
         ('boolean-filter-true', dict(
             string='foo[?flag = true].color',
-            data={'foo': [{"color": "blue", "flag": True}, {"color": "green", "flag": False}]},
+            data={'foo': [{"color": "blue", "flag": True},
+                          {"color": "green", "flag": False}]},
             target=['blue']
         )),
 
         ('boolean-filter-false', dict(
             string='foo[?flag = false].color',
-            data={'foo': [{"color": "blue", "flag": True}, {"color": "green", "flag": False}]},
+            data={'foo': [{"color": "blue", "flag": True},
+                          {"color": "green", "flag": False}]},
             target=['green']
         )),
 
         ('boolean-filter-other-datatypes-involved', dict(
             string='foo[?flag = true].color',
-            data={'foo': [{"color": "blue", "flag": True}, {"color": "green", "flag": 2}, {"color": "red", "flag": "hi"}]},
+            data={'foo': [{"color": "blue", "flag": True},
+                          {"color": "green", "flag": 2},
+                          {"color": "red", "flag": "hi"}]},
             target=['blue']
         )),
 
         ('boolean-filter-string-true-string-literal', dict(
             string='foo[?flag = "true"].color',
-            data={'foo': [{"color": "blue", "flag": True}, {"color": "green", "flag": "true"}]},
+            data={'foo': [{"color": "blue", "flag": True},
+                          {"color": "green", "flag": "true"}]},
             target=['green']
         )),
     ]

--- a/jsonpath_rw_ext/tests/test_jsonpath_rw_ext.py
+++ b/jsonpath_rw_ext/tests/test_jsonpath_rw_ext.py
@@ -299,6 +299,30 @@ class TestJsonpath_rw_ext(testscenarios.WithScenarios,
             data={'foo': [{'baz': 1}, {'baz': 2}]},
             target=[],
         )),
+
+        ('boolean-filter-true', dict(
+            string='foo[?flag = true].color',
+            data={'foo': [{"color": "blue", "flag": True}, {"color": "green", "flag": False}]},
+            target=['blue']
+        )),
+
+        ('boolean-filter-false', dict(
+            string='foo[?flag = false].color',
+            data={'foo': [{"color": "blue", "flag": True}, {"color": "green", "flag": False}]},
+            target=['green']
+        )),
+
+        ('boolean-filter-other-datatypes-involved', dict(
+            string='foo[?flag = true].color',
+            data={'foo': [{"color": "blue", "flag": True}, {"color": "green", "flag": 2}, {"color": "red", "flag": "hi"}]},
+            target=['blue']
+        )),
+
+        ('boolean-filter-string-true-string-literal', dict(
+            string='foo[?flag = "true"].color',
+            data={'foo': [{"color": "blue", "flag": True}, {"color": "green", "flag": "true"}]},
+            target=['green']
+        )),
     ]
 
     def test_fields_value(self):


### PR DESCRIPTION
Filtering with boolean values now supported.

Boolean values are expressed as `true` and `false` as [json](http://json.org).

Examples:

```
import jsonpath_rw_ext

data = [{"color": "blue", "flag": True}, {"color": "green", "flag": False}]

jsp = jsonpath_rw_ext.parse("$[?flag = true].color")
print [match.value for match in jsp.find(data)]
# prints ['blue']

jsp = jsonpath_rw_ext.parse("$[?flag = false].color")
print [match.value for match in jsp.find(data)]
# prints ['green']
```

Strings `"true"` and `"false"` can still be matched using quotes.

Closes #10 .

