### PR TITLE
Added convenience shortcut functions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,16 @@ Or::
     parser.ExtentedJsonPathParser().parse("$.foo").find(...)
 
 
-The jsonpath classes are not part of the public API, because the name/structure 
+Shortcut functions for getting only the matched values::
+
+    import jsonpath_rw_ext as jp
+    print jp.match('$.cow[*]', {'cow': ['foo', 'bar'], 'fish': 'foobar'})
+    # prints ['foo', 'bar']
+
+    print jp.match1('$.cow[*]', {'cow': ['foo', 'bar'], 'fish': 'foobar'})
+    # prints 'foo'
+
+The jsonpath classes are not part of the public API, because the name/structure
 can change when they will be implemented upstream. Only the syntax *shouldn't* 
 change.
 

--- a/jsonpath_rw_ext/__init__.py
+++ b/jsonpath_rw_ext/__init__.py
@@ -17,4 +17,4 @@ import pbr.version
 __version__ = pbr.version.VersionInfo(
     'jsonpath_rw_ext').version_string()
 
-from .parser import parse  # noqa
+from .parser import parse, match, match1  # noqa

--- a/jsonpath_rw_ext/parser.py
+++ b/jsonpath_rw_ext/parser.py
@@ -170,3 +170,14 @@ class ExtentedJsonPathParser(parser.JsonPathParser):
 
 def parse(path, debug=False):
     return ExtentedJsonPathParser(debug=debug).parse(path)
+
+
+def match(pattern, data, **kwargs):
+    """Returns all matched values of pattern in data"""
+    return [m.value for m in parse(pattern, kwargs).find(data)]
+
+
+def match1(pattern, data, **kwargs):
+    """Returns first matched value of pattern in data or None if no matches"""
+    matches = match(pattern, data, kwargs)
+    return matches[0] if matches else None

--- a/jsonpath_rw_ext/parser.py
+++ b/jsonpath_rw_ext/parser.py
@@ -172,12 +172,12 @@ def parse(path, debug=False):
     return ExtentedJsonPathParser(debug=debug).parse(path)
 
 
-def match(pattern, data, **kwargs):
+def match(pattern, data, **parse_kwargs):
     """Returns all matched values of pattern in data"""
-    return [m.value for m in parse(pattern, kwargs).find(data)]
+    return [m.value for m in parse(pattern, **parse_kwargs).find(data)]
 
 
-def match1(pattern, data, **kwargs):
+def match1(pattern, data, **parse_kwargs):
     """Returns first matched value of pattern in data or None if no matches"""
-    matches = match(pattern, data, kwargs)
+    matches = match(pattern, data, **parse_kwargs)
     return matches[0] if matches else None

--- a/jsonpath_rw_ext/tests/test_jsonpath_rw_ext.py
+++ b/jsonpath_rw_ext/tests/test_jsonpath_rw_ext.py
@@ -303,15 +303,28 @@ class TestJsonpath_rw_ext(testscenarios.WithScenarios,
 
     def test_fields_value(self):
         jsonpath.auto_id_field = None
-        result_values = parser.match(self.string, self.data, debug=True)
+        result = parser.parse(self.string, debug=True).find(self.data)
         if isinstance(self.target, list):
-            self.assertEqual(self.target, result_values)
+            self.assertEqual(self.target, [r.value for r in result])
         elif isinstance(self.target, set):
-            self.assertEqual(self.target, set(result_values))
+            self.assertEqual(self.target, set([r.value for r in result]))
         elif isinstance(self.target, (int, float)):
-            self.assertEqual(self.target, result_values[0])
+            self.assertEqual(self.target, result[0].value)
         else:
-            self.assertEqual(self.target, result_values[0])
+            self.assertEqual(self.target, result[0].value)
+
+    def test_shortcut_functions(self):
+        jsonpath.auto_id_field = None
+        parse_result = parser.parse(self.string, debug=True).find(self.data)
+        match_result = parser.match(self.string, self.data, debug=True)
+        match1_result = parser.match1(self.string, self.data, debug=True)
+
+        self.assertEqual(match_result, [r.value for r in parse_result])
+        if match_result:
+            self.assertEqual(match_result[0], match1_result)
+        else:
+            self.assertIsNone(match1_result)
+
 
 # NOTE(sileht): copy of tests/test_jsonpath.py
 # to ensure we didn't break jsonpath_rw

--- a/jsonpath_rw_ext/tests/test_jsonpath_rw_ext.py
+++ b/jsonpath_rw_ext/tests/test_jsonpath_rw_ext.py
@@ -303,15 +303,15 @@ class TestJsonpath_rw_ext(testscenarios.WithScenarios,
 
     def test_fields_value(self):
         jsonpath.auto_id_field = None
-        result = parser.parse(self.string, debug=True).find(self.data)
+        result_values = parser.match(self.string, self.data, debug=True)
         if isinstance(self.target, list):
-            self.assertEqual(self.target, [r.value for r in result])
+            self.assertEqual(self.target, result_values)
         elif isinstance(self.target, set):
-            self.assertEqual(self.target, set([r.value for r in result]))
+            self.assertEqual(self.target, set(result_values))
         elif isinstance(self.target, (int, float)):
-            self.assertEqual(self.target, result[0].value)
+            self.assertEqual(self.target, result_values[0])
         else:
-            self.assertEqual(self.target, result[0].value)
+            self.assertEqual(self.target, result_values[0])
 
 # NOTE(sileht): copy of tests/test_jsonpath.py
 # to ensure we didn't break jsonpath_rw


### PR DESCRIPTION
In the `re.match` style; examples:

```
import jsonpath_rw_ext as jp
print jp.match('$.cow[*]', {'cow': ['foo', 'bar'], 'fish': 'foobar'})
# prints ['foo', 'bar']

print jp.match1('$.cow[*]', {'cow': ['foo', 'bar'], 'fish': 'foobar'})
# prints 'foo'
```