### PR TITLE
Use modern PBR and hacking packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-pbr<2.0,>=1.4
+pbr>=1.8
 Babel>=1.3
 jsonpath-rw>=1.2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-hacking<0.11,>=0.10.0
+hacking>=0.12.0,!=0.13.0,<0.14
 
 coverage>=3.6
 discover


### PR DESCRIPTION
The 2.0.0 is breaking in that it removes the use of warnerrors in
build_sphinux.

jsonpath-rw-ext isn't using that feature, so it shoudln't break.

The cap on pbr is preventing other OpenStack projects that would like to
use pbr 2.0.0 (and sphinx 1.5.1) from doing so as it breaks
co-installability with jsonpath-rw-ext

Also hacking <0.11 had a similar issue so use a newer version of that also

Related-Bug: 1668848