### PR TITLE
return original value if `sub` didn't match any pattern

### DIFF
--- a/jsonpath_rw_ext/_string.py
+++ b/jsonpath_rw_ext/_string.py
@@ -43,10 +43,8 @@ class Sub(jsonpath_rw.This):
     def find(self, datum):
         datum = jsonpath_rw.DatumInContext.wrap(datum)
         value = self.regex.sub(self.repl, datum.value)
-        if value == datum.value:
-            return []
-        else:
-            return [jsonpath_rw.DatumInContext.wrap(value)]
+
+        return [jsonpath_rw.DatumInContext.wrap(value)]
 
     def __eq__(self, other):
         return (isinstance(other, Sub) and self.method == other.method)


### PR DESCRIPTION
python sub method always return the original value even if there was no match and replacement. 
to be consistent with python, this PR propose to remove checking if value hasn't changed and return the original value as it as.
current behavior:
```
>>> re.sub(r'foo', 'bar', 'github')
''
```

expected behavior:

```
>>> re.sub(r'foo', 'bar', 'github')
'github'
```



